### PR TITLE
LIBWEB-5747. Suggested updates from review

### DIFF
--- a/monitors/blueprints/api/mapi.py
+++ b/monitors/blueprints/api/mapi.py
@@ -1,8 +1,6 @@
 import requests
 import monitors
 import json
-import datetime
-import time
 
 from flask import Blueprint
 from collections import OrderedDict

--- a/monitors/blueprints/frontend/displays.py
+++ b/monitors/blueprints/frontend/displays.py
@@ -14,7 +14,7 @@ def mckeldin():
     try:
         return render_template('mckeldin.html')
     except TemplateNotFound:
-        about(404)
+        abort(404)
 
 
 @displays.route('/stem')
@@ -22,7 +22,7 @@ def stem():
     try:
         return render_template('stem.html')
     except TemplateNotFound:
-        about(404)
+        abort(404)
 
 
 @displays.route('/mckeldin-workstations-legacy')
@@ -41,7 +41,7 @@ def mckeldin_workstations_legacy():
                                library_name="McKeldin",
                                availability_results=avail)
     except TemplateNotFound:
-        about(404)
+        abort(404)
 
 
 @displays.route('/stem-workstations-legacy')
@@ -66,7 +66,7 @@ def stem_workstations_legacy():
                                availability_results=avail,
                                nearby_results=nearby_avail)
     except TemplateNotFound:
-        about(404)
+        abort(404)
 
 
 @displays.route('/stem-equipment-legacy')
@@ -86,7 +86,7 @@ def stem_equipment_legacy():
                                library_name="STEM",
                                availability_results=avail)
     except TemplateNotFound:
-        about(404)
+        abort(404)
 
 
 @displays.route('/mckeldin-equipment-legacy')
@@ -106,4 +106,4 @@ def mckeldin_equipment_legacy():
                                library_name="STEM",
                                availability_results=avail)
     except TemplateNotFound:
-        about(404)
+        abort(404)


### PR DESCRIPTION

* monitors/blueprints/frontend/displays.py - Replaced calls to "about" method (which was undefined) to "abort", which seems correct based on the context and imports.
* monitors/blueprints/api/mapi.py - Removed unused imports reported by Pylance

https://issues.umd.edu/browse/LIBWEB-5747